### PR TITLE
Fix version spacing in Project View for IntelliJ 2026.x (fixes #7)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,8 +53,7 @@ intellijPlatform {
     }
 
     publishing {
-        val intellijPublishToken: String by project
-        token = intellijPublishToken
+        token.set(providers.gradleProperty("intellijPublishToken"))
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,12 @@
-rootProject.name = "maven-version-idea-plugin"
-
 pluginManagement {
     repositories {
         maven("https://oss.sonatype.org/content/repositories/snapshots/")
         gradlePluginPortal()
     }
 }
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
+rootProject.name = "maven-version-idea-plugin"

--- a/src/main/kotlin/com/github/novotnyr/mavenversion/MavenVersionProjectViewDecorator.kt
+++ b/src/main/kotlin/com/github/novotnyr/mavenversion/MavenVersionProjectViewDecorator.kt
@@ -33,8 +33,8 @@ class MavenVersionProjectViewDecorator : ProjectViewNodeDecorator {
 
     private val separator: String
         get() = when {
+            ApplicationInfo.getInstance().build.baselineVersion >= 261 -> "  "
             SystemInfo.isWindows -> "  "
-            ApplicationInfo.getInstance().build.baselineVersion >= 261 -> " "
             else -> "\t"
         }
 }


### PR DESCRIPTION
### Description

This PR resolves issue #7 where the Maven version in the Project View was rendered too close to the module name starting in IntelliJ IDEA 2026.x. It also updates the Gradle configuration so that developers can build the plugin locally without setup errors.

### Changes

#### 1. Fix version spacing in Project View for IntelliJ 2026.x
* Previously, when the baseline version was detected as `>= 261` (2026.1+), the separator fell back to a single space (`" "`).
* In proportional fonts, a single space is extremely thin, causing the version to appear attached directly to the module name.
* Changed the separator for baseline version `>= 261` to two spaces (`"  "`) to restore clear visual separation (matching the existing spacing used on Windows).

#### 2. Fix local Gradle configuration & JVM Toolchain download
* Refactored `intellijPublishToken` configuration to use Gradle's `providers.gradleProperty` instead of a direct delegated property delegate. This prevents local builds from crashing when the publishing token is missing in `gradle.properties`.
* Added the standard `foojay-resolver-convention` plugin (v1.0.0) in `settings.gradle.kts` to enable automatic JDK 17 downloading and resolution, resolving build failures on machines without a pre-configured local JDK 17 toolchain.

### Verification
* Verified that the project builds successfully with `./gradlew buildPlugin` and `./gradlew check`.
* Visual separation matches the desired behavior of clearly distinguishing the version from the folder name.

### Closes
Closes #7
